### PR TITLE
Implement category function when create XML of Atom

### DIFF
--- a/autoload/webapi/atom.vim
+++ b/autoload/webapi/atom.vim
@@ -95,6 +95,14 @@ function! s:createXml(entry)
         let node.attr["mode"] = a:entry['content.mode']
       endif
       call add(entry.child, node)
+    elseif l:keytype == 3
+      if key == "category"
+        for l:category in a:entry['category']
+          let node = webapi#xml#createElement(key)
+          let node.attr["term"] = l:category
+          call add(entry.child, node)
+        endfor
+      endif
     elseif l:keytype == 4
       let node = webapi#xml#createElement(key)
       if key == "app:control"


### PR DESCRIPTION
Hello,

AtomPub API can specify categories of entry, however this library cannot configure them in appearance.
So I implemented.

Could you review this?
