### PR TITLE
Unicode quotes pattern in json decode

### DIFF
--- a/autoload/webapi/json.vim
+++ b/autoload/webapi/json.vim
@@ -74,7 +74,7 @@ function! webapi#json#decode(json)
     throw json
   endif
   let json = substitute(json, '\n', '', 'g')
-  let json = substitute(json, '\\u34;', '\\"', 'g')
+  let json = substitute(json, '\\u\(34;\|0022\)', '\\"', 'g')
   if v:version >= 703 && has('patch780')
     let json = substitute(json, '\\u\(\x\x\x\x\)', '\=iconv(nr2char(str2nr(submatch(1), 16), 1), "utf-8", &encoding)', 'g')
   else


### PR DESCRIPTION
I have met some situations that use hex code '\u0022' to represent the quotation mark.
If not replaced, it will mess the hole expression, thus eval(json) will fail.
