### PR TITLE
Add socks support with curl (via g:webapi#socks5 variable)

### DIFF
--- a/autoload/webapi/http.vim
+++ b/autoload/webapi/http.vim
@@ -141,6 +141,9 @@ function! webapi#http#get(url, ...)
         let command .= " -H " . quote . key . ": " . headdata[key] . quote
       endif
     endfor
+    if exists("g:webapi#socks5")
+      let command .= " --socks5 ". g:webapi#socks5
+    endif
     let command .= " ".quote.url.quote
     let res = s:system(command)
   elseif executable('wget')


### PR DESCRIPTION
With curl you can set a socks5 proxy to be used via the command.  I needed this for some work related functions I was making and thought it might be useful enough to have.  I didn't write any documentation for the global variable but wanted to throw this out there in case you wanted to take the plugin in this direction.