### PR TITLE
Support HTTP/2 response

### DIFF
--- a/autoload/webapi/http.vim
+++ b/autoload/webapi/http.vim
@@ -159,7 +159,7 @@ function! webapi#http#get(url, ...) abort
     throw "require `curl` or `wget` command"
   endif
   if follow != 0
-    while res =~ '^HTTP/1.\d 3' || res =~ '^HTTP/1\.[01] [0-9]\{3} .\+\n\r\?\nHTTP/1\.[01] [0-9]\{3} .\+'
+    while res =~# '^HTTP/\%(1\.[01]\|2\%(\.0\)\?\) 3' || res =~# '^HTTP/1\.[01] [0-9]\{3} .\+\n\r\?\nHTTP/1\.[01] [0-9]\{3} .\+'
       let pos = stridx(res, "\r\n\r\n")
       if pos != -1
         let res = strpart(res, pos+4)
@@ -177,7 +177,7 @@ function! webapi#http#get(url, ...) abort
     let content = strpart(res, pos+2)
   endif
   let header = split(res[:pos-1], '\r\?\n')
-  let matched = matchlist(get(header, 0), '^HTTP/1\.\d\s\+\(\d\+\)\s\+\(.*\)')
+  let matched = matchlist(get(header, 0), '^HTTP/\%(1\.[01]\|2\%(\.0\)\?\)\s\+\(\d\+\)\s*\(.*\)')
   if !empty(matched)
     let [status, message] = matched[1 : 2]
     call remove(header, 0)
@@ -240,7 +240,7 @@ function! webapi#http#post(url, ...) abort
   endif
   call delete(file)
   if follow != 0
-    while res =~ '^HTTP/1.\d 3' || res =~ '^HTTP/1\.[01] [0-9]\{3} .\+\n\r\?\nHTTP/1\.[01] [0-9]\{3} .\+'
+    while res =~# '^HTTP/\%(1\.[01]\|2\%(\.0\)\?\) 3' || res =~# '^HTTP/1\.[01] [0-9]\{3} .\+\n\r\?\nHTTP/1\.[01] [0-9]\{3} .\+'
       let pos = stridx(res, "\r\n\r\n")
       if pos != -1
         let res = strpart(res, pos+4)
@@ -258,7 +258,7 @@ function! webapi#http#post(url, ...) abort
     let content = strpart(res, pos+2)
   endif
   let header = split(res[:pos-1], '\r\?\n')
-  let matched = matchlist(get(header, 0), '^HTTP/1\.\d\s\+\(\d\+\)\s\+\(.*\)')
+  let matched = matchlist(get(header, 0), '^HTTP/\%(1\.[01]\|2\%(\.0\)\?\)\s\+\(\d\+\)\s*\(.*\)')
   if !empty(matched)
     let [status, message] = matched[1 : 2]
     call remove(header, 0)


### PR DESCRIPTION
Hi, mattn.

Some people start using HTTP/2 enabled curl. With the current curl implementation, message looks like:
```
 $ curl -I --http2 https://nghttp2.org
HTTP/2 200 
date: Tue, 05 Jul 2016 14:47:54 GMT
content-type: text/html
last-modified: Sun, 26 Jun 2016 13:34:04 GMT
etag: "576fd9cc-19f3"
accept-ranges: bytes
content-length: 6643
x-backend-header-rtt: 0.001317
strict-transport-security: max-age=31536000
server: nghttpx nghttp2/1.13.0-DEV
via: 2 nghttpx
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
```
The minor version is not printed (see https://github.com/curl/curl/blob/38685f86c8709c0670e81812b98f8181814212bf/lib/http2.c#L880), but older version of curl seem to print as `HTTP/2.0` (ref: https://github.com/curl/curl/commit/8243a9581b7782bc2af29e8421952d0e669f9e9e). Note that the message is not available anymore. I also noticed that the feature following redirects is not implement yet (`curl -I -L --http2 https://youtube.com` does not work while `curl -I -L --http1.1 https://youtube.com` does work).
Some examples:
```vim
:echo webapi#http#get('https://nghttp2.org')
:echo webapi#http#post('https://nghttp2.org')
```