### PR TITLE
webapi#http#encodeURIComponent: also encode tilde ('~')

### DIFF
--- a/autoload/webapi/http.vim
+++ b/autoload/webapi/http.vim
@@ -109,7 +109,7 @@ function! webapi#http#encodeURIComponent(items) abort
     let i = 0
     while i < len
       let ch = items[i]
-      if ch =~# '[0-9A-Za-z-._~!''()*]'
+      if ch =~# '[0-9A-Za-z-._!''()*]'
         let ret .= ch
       elseif ch == ' '
         let ret .= '+'


### PR DESCRIPTION
While the tilde character ('~') is not a reserved character, it is "unsafe" according to [RFC 1738](https://tools.ietf.org/html/rfc1738) and thus must be encoded. I found that python's [urllib.quote()](https://docs.python.org/2/library/urllib.html#urllib.quote) does encode it, and also that the simplenote api doesn't work without it being encoded.

See also https://github.com/mattn/vim-metarw-simplenote/pull/2