### PR TITLE
fix typo

### DIFF
--- a/example/twitter.vim
+++ b/example/twitter.vim
@@ -25,7 +25,7 @@ function! s:tweet(status) abort
       return
     endif
     if has('win32') || has('win64')
-      exe printf('!start rundll32 url.dll,FileProtocolHandler %s?oauth_token=%s', auth_url, .ctx.request_token)
+      exe printf('!start rundll32 url.dll,FileProtocolHandler %s?oauth_token=%s', auth_url, ctx.request_token)
     else
       call system(printf("xdg-open '%s?oauth_token=%s'", auth_url, ctx.request_token))
     endif


### PR DESCRIPTION
I think `.ctx.request_token` is typo. Please check this code.

If this code isn't typo, I'm sorry.