### PR TITLE
Fix cannot parse img tag whose end of attr is not surrounded by quotation

### DIFF
--- a/autoload/webapi/html.vim
+++ b/autoload/webapi/html.vim
@@ -56,7 +56,7 @@ function! webapi#html#encodeEntityReference(str) abort
 endfunction
 
 function! webapi#html#parse(html) abort
-  let html = substitute(a:html, '<\(area\|base\|basefont\|br\|nobr\|col\|frame\|hr\|img\|input\|isindex\|link\|meta\|param\|embed\|keygen\|command\)\([^>]*[^/]\|\)>', '<\1\2/>', 'g')
+  let html = substitute(a:html, '<\(area\|base\|basefont\|br\|nobr\|col\|frame\|hr\|img\|input\|isindex\|link\|meta\|param\|embed\|keygen\|command\)\([^>]*[^/]\|\)>', '<\1\2 />', 'g')
   return webapi#xml#parse(html)
 endfunction
 


### PR DESCRIPTION
This html can not parse correctly.
```html
<div>
    <img class=1>
    <img class=2>
</div>
```
I except `.childNodes('img')[0].toString()` is `<img class="1">`, but the result was `<img class="1" /="">
    <img class="2" /="">
</img></img>`

use `<img class=1 />` instead of `<img class=1/>` will resolve the problem.