### PR TITLE
Fix invalid helptag for JSON Parser

### DIFF
--- a/doc/webapi.txt
+++ b/doc/webapi.txt
@@ -10,7 +10,7 @@ CONTENTS				*webapi-contents* *webapi* *web-api*
 
 XML Parser				|webapi-xml|
 HTML Parser				|webapi-html|
-JSON Parser				|json-html|
+JSON Parser				|webapi-json|
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl


### PR DESCRIPTION
This fixes tag jumping to the JSON Parser doc.